### PR TITLE
实现默认收件人配置功能

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,497 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="SMART_TABS" value="true" />
+      </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="90" />
+    <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
+    <option name="SOFT_MARGINS" value="90" />
+    <HTMLCodeStyleSettings>
+      <option name="HTML_ATTRIBUTE_WRAP" value="0" />
+      <option name="HTML_KEEP_LINE_BREAKS_IN_TEXT" value="false" />
+      <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+      <option name="HTML_ELEMENTS_TO_INSERT_NEW_LINE_BEFORE" value="body,head" />
+      <option name="HTML_ELEMENTS_TO_REMOVE_NEW_LINE_BEFORE" value="" />
+      <option name="HTML_DO_NOT_INDENT_CHILDREN_OF" value="html" />
+      <option name="HTML_INLINE_ELEMENTS" value="" />
+      <option name="HTML_DONT_ADD_BREAKS_IF_INLINE_CONTENT" value="" />
+      <option name="HTML_ENFORCE_QUOTES" value="true" />
+    </HTMLCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
+      <option name="REFORMAT_C_STYLE_COMMENTS" value="true" />
+    </JSCodeStyleSettings>
+    <JavaCodeStyleSettings>
+      <option name="SUBCLASS_NAME_SUFFIX" value="" />
+      <option name="GENERATE_FINAL_PARAMETERS" value="true" />
+      <option name="SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENT" value="true" />
+      <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+      <option name="ANNOTATION_PARAMETER_WRAP" value="1" />
+      <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true" />
+      <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="java" withSubpackages="true" static="false" />
+          <package name="javax" withSubpackages="true" static="false" />
+          <package name="javafx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="javafx" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="true" />
+        </value>
+      </option>
+      <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true" />
+      <option name="JD_ADD_BLANK_AFTER_RETURN" value="true" />
+      <option name="JD_KEEP_INVALID_TAGS" value="false" />
+      <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+      <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+      <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
+      <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+      <option name="JD_PARAM_DESCRIPTION_ON_NEW_LINE" value="true" />
+      <option name="JD_INDENT_ON_CONTINUATION" value="true" />
+    </JavaCodeStyleSettings>
+    <XML>
+      <option name="XML_ATTRIBUTE_WRAP" value="0" />
+      <option name="XML_KEEP_LINE_BREAKS" value="false" />
+      <option name="XML_KEEP_LINE_BREAKS_IN_TEXT" value="false" />
+      <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+      <option name="XML_WHITE_SPACE_AROUND_CDATA" value="1" />
+    </XML>
+    <yaml>
+      <option name="SEQUENCE_ON_NEW_LINE" value="true" />
+      <option name="BLOCK_MAPPING_ON_NEW_LINE" value="true" />
+    </yaml>
+    <codeStyleSettings language="HTML">
+      <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BETWEEN_PACKAGE_DECLARATION_AND_HEADER" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+      <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_ASSIGNMENT" value="true" />
+      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
+      <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+      <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
+      <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+      <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+      <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="PREFER_PARAMETERS_WRAP" value="true" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="RESOURCE_LIST_WRAP" value="1" />
+      <option name="RESOURCE_LIST_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="RESOURCE_LIST_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="THROWS_LIST_WRAP" value="1" />
+      <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+      <option name="THROWS_KEYWORD_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+      <option name="WRAP_FIRST_METHOD_IN_CALL_CHAIN" value="true" />
+      <option name="PARENTHESES_EXPRESSION_LPAREN_WRAP" value="true" />
+      <option name="PARENTHESES_EXPRESSION_RPAREN_WRAP" value="true" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+      <option name="KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="FOR_STATEMENT_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="PLACE_ASSIGNMENT_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="WRAP_COMMENTS" value="true" />
+      <option name="ASSERT_STATEMENT_WRAP" value="1" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="WRAP_LONG_LINES" value="true" />
+      <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+      <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
+      <option name="ENUM_CONSTANTS_WRAP" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <tokens>
+          <token id="visibility" name="visibility">
+            <rules>
+              <rule>
+                <match>
+                  <PRIVATE>true</PRIVATE>
+                </match>
+              </rule>
+              <rule>
+                <match>
+                  <PROTECTED>true</PROTECTED>
+                </match>
+              </rule>
+              <rule>
+                <match>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                </match>
+              </rule>
+              <rule>
+                <match>
+                  <PUBLIC>true</PUBLIC>
+                </match>
+              </rule>
+            </rules>
+          </token>
+        </tokens>
+        <groups>
+          <group>
+            <type>GETTERS_AND_SETTERS</type>
+            <order>KEEP</order>
+          </group>
+          <group>
+            <type>DEPENDENT_METHODS</type>
+            <order>DEPTH_FIRST</order>
+          </group>
+          <group>
+            <type>OVERRIDDEN_METHODS</type>
+            <order>BY_NAME</order>
+          </group>
+        </groups>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PRIVATE>true</PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PROTECTED>true</PROTECTED>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PUBLIC>true</PUBLIC>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PRIVATE>true</PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PROTECTED>true</PROTECTED>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PUBLIC>true</PUBLIC>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PRIVATE>true</PRIVATE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PROTECTED>true</PROTECTED>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <PUBLIC>true</PUBLIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PRIVATE>true</PRIVATE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PROTECTED>true</PROTECTED>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <PUBLIC>true</PUBLIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <ENUM>true</ENUM>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <INTERFACE>true</INTERFACE>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <CLASS>true</CLASS>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <CLASS>true</CLASS>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <CONSTRUCTOR>true</CONSTRUCTOR>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <METHOD>true</METHOD>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <METHOD>true</METHOD>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSON">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSP">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+      <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+    </codeStyleSettings>
+    <codeStyleSettings language="Markdown">
+      <option name="RIGHT_MARGIN" value="0" />
+      <option name="WRAP_ON_TYPING" value="0" />
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/copyright/MIT_License.xml
+++ b/.idea/copyright/MIT_License.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="MIT License&#10;&#10;Copyright (c) &amp;#36;today.year Dragon1573&#10;&#10;Permission is hereby granted, free of charge, to any person obtaining a copy&#10;of this software and associated documentation files (the &quot;Software&quot;), to deal&#10;in the Software without restriction, including without limitation the rights&#10;to use, copy, modify, merge, publish, distribute, sublicense, and/or sell&#10;copies of the Software, and to permit persons to whom the Software is&#10;furnished to do so, subject to the following conditions:&#10;&#10;The above copyright notice and this permission notice shall be included in all&#10;copies or substantial portions of the Software.&#10;&#10;THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR&#10;IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,&#10;FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE&#10;AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER&#10;LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,&#10;OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE&#10;SOFTWARE." />
+    <option name="myName" value="MIT License" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,8 @@
+<component name="CopyrightManager">
+  <settings>
+    <module2copyright>
+      <element module="All" copyright="MIT License" />
+    </module2copyright>
+    <LanguageOptions name="__TEMPLATE__" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -93,5 +93,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="Oracle JDK 11.0.4" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="Oracle JDK 8" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -93,5 +93,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="Oracle JDK 11.0.4" project-jdk-type="JavaSDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
-<div style="text-align: center;">
-  <img src="introduction.png"  alt="A Git-like CLI Tool for homework submission" />
-  <br /><br />
-  <p style="text-align: center;">
-    <a href="https://github.com/Dragon1573/Git-Homework/blob/master/LICENSE">
-      <img src="https://img.shields.io/github/license/Dragon1573/Git-Homework?style=flat&label=License" alt="GitHub license" />
-    </a>
-    <a href="https://github.com/Dragon1573/Git-Homework/actions?query=workflow%3A%22Apache+Maven+CI%22">
-      <img src="https://github.com/Dragon1573/Git-Homework/workflows/Apache%20Maven%20CI/badge.svg" alt="Apache Maven CI" />
-    </a>
-  </p>
-  <a href="https://github.com/Dragon1573/Git-Homework/wiki/%E9%A6%96%E9%A1%B5">
-    项目介绍（简体中文版）
-  </a>
-  <br />
-  <a href="https://github.com/Dragon1573/Git-Homework/wiki">
-    Introduction (English Version)
-  </a>
-</div>
+# `Homework` - A Git-like CLI Tool for homework submission
+
+![Introduction Logo](introduction.png)
+
+[![MIT License](https://img.shields.io/github/license/Dragon1573/Git-Homework?style=flat&label=License)](https://github.com/Dragon1573/Git-Homework/blob/master/LICENSE)
+[![Apache Maven CI](https://github.com/Dragon1573/Git-Homework/workflows/Apache%20Maven%20CI/badge.svg)](https://github.com/Dragon1573/Git-Homework/actions?query=workflow%3A%22Apache+Maven+CI%22)
+
+- [项目介绍（简体中文版）](https://github.com/Dragon1573/Git-Homework/wiki/%E9%A6%96%E9%A1%B5)
+- [Introduction (English Version)](https://github.com/Dragon1573/Git-Homework/wiki)
+
+## 公告
+
+&emsp;&emsp;从即日起，本仓库将**被归档**并进入“佛系更新”状态。如果您对此项目感兴趣，且有意愿改进本项目，请 **Fork** 本仓库。
+
+&emsp;&emsp;感谢大家的支持与厚爱～
+
+## Announcement
+
+From today on, this repository will be **archived** and entering a randomly-update state. If you have interests in this project, please **fork** this repository.
+
+Thank you!

--- a/homework/pom.xml
+++ b/homework/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>io.github.dragon1573</groupId>
   <artifactId>homework</artifactId>
-  <version>0.4.1</version>
+  <version>0.4.2</version>
   <packaging>jar</packaging>
 
   <name>homework</name>

--- a/homework/pom.xml
+++ b/homework/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>io.github.dragon1573</groupId>
   <artifactId>homework</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <packaging>jar</packaging>
 
   <name>homework</name>

--- a/homework/pom.xml
+++ b/homework/pom.xml
@@ -35,9 +35,9 @@
 
   <properties>
     <encoding>UTF-8</encoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.compilerVersion>11</maven.compiler.compilerVersion>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.compilerVersion>8</maven.compiler.compilerVersion>
   </properties>
 
   <inceptionYear>2020</inceptionYear>

--- a/homework/pom.xml
+++ b/homework/pom.xml
@@ -1,3 +1,27 @@
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2020 Dragon1573
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

--- a/homework/src/main/java/functions/Archive.java
+++ b/homework/src/main/java/functions/Archive.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package functions;
 
 import java.io.*;

--- a/homework/src/main/java/functions/Archive.java
+++ b/homework/src/main/java/functions/Archive.java
@@ -36,43 +36,6 @@ import org.apache.tools.zip.ZipOutputStream;
  */
 public class Archive {
     /**
-     * 创建压缩文件
-     *
-     * @param args
-     *     命令行参数
-     */
-    public static void compress(final String[] args) {
-        // 目标压缩文件名
-        String targetName = args[1] + ".zip";
-        try {
-            // 文件字节输出流
-            FileOutputStream fileStream = new FileOutputStream(targetName);
-            // 压缩文件输出流
-            ZipOutputStream zipStream = new ZipOutputStream(
-                new BufferedOutputStream(fileStream)
-            );
-
-            // 循环遍历命令行参数中的文件
-            for (int i = 2; i < args.length; i++) {
-                // 待压缩资源文件
-                File resource = new File(args[i]);
-                // 将资源添加到压缩文件中
-                append(zipStream, resource, "");
-            }
-
-            // 关闭流
-            zipStream.close();
-            fileStream.close();
-        } catch (IOException e) {
-            System.err.println(e.getLocalizedMessage());
-            System.err.println(
-                "[Error] Cannot create the archive file! " +
-                "Please try again ..."
-            );
-        }
-    }
-
-    /**
      * 递归添加资源文件/目录
      *
      * @param zipStream
@@ -112,7 +75,8 @@ public class Archive {
                 zipStream.putNextEntry(new ZipEntry(folder));
 
                 // 写入文件
-                byte[] contents = fileStream.readAllBytes();
+                byte[] contents = new byte[fileStream.available()];
+                fileStream.read(contents, 0, fileStream.available());
                 zipStream.write(contents);
             } catch (IOException e) {
                 System.err.println(e.getLocalizedMessage());
@@ -121,6 +85,43 @@ public class Archive {
                     "Please make sure you gave us a correct path ..."
                 );
             }
+        }
+    }
+
+    /**
+     * 创建压缩文件
+     *
+     * @param args
+     *     命令行参数
+     */
+    public static void compress(final String[] args) {
+        // 目标压缩文件名
+        String targetName = args[1] + ".zip";
+        try {
+            // 文件字节输出流
+            FileOutputStream fileStream = new FileOutputStream(targetName);
+            // 压缩文件输出流
+            ZipOutputStream zipStream = new ZipOutputStream(
+                new BufferedOutputStream(fileStream)
+            );
+
+            // 循环遍历命令行参数中的文件
+            for (int i = 2; i < args.length; i++) {
+                // 待压缩资源文件
+                File resource = new File(args[i]);
+                // 将资源添加到压缩文件中
+                append(zipStream, resource, "");
+            }
+
+            // 关闭流
+            zipStream.close();
+            fileStream.close();
+        } catch (IOException e) {
+            System.err.println(e.getLocalizedMessage());
+            System.err.println(
+                "[Error] Cannot create the archive file! " +
+                "Please try again ..."
+            );
         }
     }
 }

--- a/homework/src/main/java/functions/Config.java
+++ b/homework/src/main/java/functions/Config.java
@@ -53,6 +53,7 @@ public class Config {
             case Constants.EMAIL:
             case Constants.SMTP:
             case Constants.KEY:
+            case Constants.DEFAULT_TARGET:
                 Configurations configurations = load();
                 if (args.length >= Constants.THREE) {
                     // 存在第三参数，则进行设置
@@ -108,7 +109,7 @@ public class Config {
             writer.close();
         } catch (IOException e) {
             e.printStackTrace();
-            assert false : "Can't save profiles!";
+            throw new AssertionError("[Error] Can't save your profile!", e);
         }
     }
 }

--- a/homework/src/main/java/functions/Config.java
+++ b/homework/src/main/java/functions/Config.java
@@ -79,7 +79,8 @@ public class Config {
     public static Configurations load() {
         Configurations configurations = new Configurations();
         try (FileInputStream stream = new FileInputStream(new File(GLOBAL_CONF))) {
-            byte[] base64 = stream.readAllBytes();
+            byte[] base64 = new byte[stream.available()];
+            stream.read(base64, 0, stream.available());
             Decoder decoder = Base64.getDecoder();
             String json = new String(decoder.decode(base64), StandardCharsets.UTF_8);
             Configurations temp = JSON.parseObject(json, Configurations.class);

--- a/homework/src/main/java/functions/Config.java
+++ b/homework/src/main/java/functions/Config.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package functions;
 
 import java.io.File;

--- a/homework/src/main/java/functions/Config.java
+++ b/homework/src/main/java/functions/Config.java
@@ -68,7 +68,7 @@ public class Config {
             default:
                 System.err.println("[Waring] Settings unknown!");
                 System.out.println();
-                System.out.println("Please");
+                System.out.println("Use \"homework -h\" for help.");
                 break;
         }
     }

--- a/homework/src/main/java/functions/Help.java
+++ b/homework/src/main/java/functions/Help.java
@@ -36,12 +36,13 @@ import static java.util.Objects.requireNonNull;
  * @author Dragon1573
  */
 public class Help {
-    public static void print() {
+    public static void print() throws IOException {
         ClassLoader loader = Help.class.getClassLoader();
         InputStream stream = loader.getResourceAsStream("help.txt");
-        byte[] bytes = new byte[0];
+        assert stream != null;
+        byte[] bytes = new byte[stream.available()];
         try {
-            bytes = requireNonNull(stream).readAllBytes();
+            requireNonNull(stream).read(bytes, 0, stream.available());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/homework/src/main/java/functions/Help.java
+++ b/homework/src/main/java/functions/Help.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package functions;
 
 import java.io.IOException;

--- a/homework/src/main/java/functions/Push.java
+++ b/homework/src/main/java/functions/Push.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package functions;
 
 import java.security.GeneralSecurityException;

--- a/homework/src/main/java/functions/Push.java
+++ b/homework/src/main/java/functions/Push.java
@@ -40,11 +40,9 @@ import javax.mail.internet.MimeMultipart;
 import com.sun.mail.util.MailSSLSocketFactory;
 
 import utils.Configurations;
+import utils.Constants;
 
 import static javax.mail.Message.RecipientType.TO;
-
-import static utils.Constants.ONE;
-import static utils.Constants.TWO;
 
 /**
  * 发送电子邮件
@@ -54,32 +52,46 @@ import static utils.Constants.TWO;
 public class Push {
     /**
      * 主动作
+     *
+     * @param args
+     *     命令行参数
      */
     public static void actions(final String[] args) {
-        System.out.println();
-        if (send(args[ONE], args[TWO])) {
-            System.out.println("[Info] Send succeeded :-)");
+        if (args.length < Constants.THREE) {
+            Configurations configurations = Config.load();
+            try {
+                send(args[1], configurations.getTarget());
+                System.out.println("Send succeeded :-)");
+            } catch (MessagingException e) {
+                System.err.println(e.getLocalizedMessage());
+                System.err.println("Send failed :-(");
+                System.err.println("Please check your profile and try again later ...");
+            }
         } else {
-            System.out.println("[Info] Send failed :-(");
-            throw new AssertionError();
+            try {
+                send(args[1], args[2]);
+                System.out.println("Send succeeded :-)");
+            } catch (MessagingException e) {
+                System.err.println(e.getLocalizedMessage());
+                System.err.println("Send failed :-(");
+                System.err.println("Please check your profile and try again later ...");
+            }
         }
     }
 
     /**
      * 发送电子邮件
-     *
-     * @return 邮件发送成功反馈
      */
-    private static boolean send(final String filePath, final String address) {
+    private static void send(final String filePath, final String address)
+        throws MessagingException {
         Configurations configurations = Config.load();
         if (configurations.isUnset()) {
             System.err.println(
                 "You haven't told us about yourself! " +
                 "Please help us identify you by using command 'homework config'."
             );
-            return false;
+            return;
         }
-        boolean isSuccess = false;
         // 获取系统属性
         Properties properties = System.getProperties();
         // 设置发信服务器
@@ -157,10 +169,6 @@ public class Push {
             message.setContent(multipart);
             // 发送邮件
             Transport.send(message);
-            isSuccess = true;
-        } catch (MessagingException e) {
-            System.err.println(e.getLocalizedMessage());
         }
-        return isSuccess;
     }
 }

--- a/homework/src/main/java/main/App.java
+++ b/homework/src/main/java/main/App.java
@@ -65,7 +65,7 @@ public class App {
 
                 case Constants.PUSH:
                     // 作业推送（发送电子邮件）
-                    if (args.length < Constants.THREE) {
+                    if (args.length < Constants.TWO) {
                         System.err.println("Arguments incomplete!");
                         System.err.println();
                         System.err.println("Type 'homework -h' for help.");

--- a/homework/src/main/java/main/App.java
+++ b/homework/src/main/java/main/App.java
@@ -36,7 +36,7 @@ import utils.Constants;
  * @author Dragon1573
  */
 public class App {
-    private static final String VERSION = "0.4.0";
+    private static final String VERSION = "0.4.1";
 
     /**
      * 主函数

--- a/homework/src/main/java/main/App.java
+++ b/homework/src/main/java/main/App.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package main;
 
 import functions.Archive;

--- a/homework/src/main/java/main/App.java
+++ b/homework/src/main/java/main/App.java
@@ -36,7 +36,7 @@ import utils.Constants;
  * @author Dragon1573
  */
 public class App {
-    private static final String VERSION = "0.4.1";
+    private static final String VERSION = "0.4.2";
 
     /**
      * 主函数

--- a/homework/src/main/java/main/App.java
+++ b/homework/src/main/java/main/App.java
@@ -24,6 +24,8 @@
 
 package main;
 
+import java.io.IOException;
+
 import functions.Archive;
 import functions.Config;
 import functions.Help;
@@ -44,7 +46,7 @@ public class App {
      * @param args
      *     命令行参数
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         if (args.length == 0) {
             // 没有指定参数/命令时，输出帮助文档
             Help.print();

--- a/homework/src/main/java/utils/Configurations.java
+++ b/homework/src/main/java/utils/Configurations.java
@@ -24,9 +24,6 @@
 
 package utils;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * 用户配置实例类
  *
@@ -37,7 +34,6 @@ public class Configurations {
     private String smtp = "";
     private String password = "";
     private String target = "";
-    private List<String> targetList = new ArrayList<>();
 
     /**
      * 设置配置
@@ -54,6 +50,8 @@ public class Configurations {
             smtp = value;
         } else if (Constants.KEY.equals(item)) {
             password = value;
+        } else if (Constants.DEFAULT_TARGET.equals(item)) {
+            target = value;
         }
     }
 
@@ -70,6 +68,8 @@ public class Configurations {
             System.out.println(getSmtp());
         } else if (Constants.KEY.equals(item)) {
             System.out.println("*".repeat(getPassword().length()));
+        } else if (Constants.DEFAULT_TARGET.equals(item)) {
+            System.out.println(getTarget());
         }
     }
 
@@ -131,17 +131,6 @@ public class Configurations {
     }
 
     /**
-     * 检查用户配置是否为空
-     *
-     * @return {@code boolean}
-     */
-    public final boolean isUnset() {
-        return (
-            "".equals(getEmail()) && "".equals(getSmtp()) && "".equals(getPassword())
-        );
-    }
-
-    /**
      * 获取默认收件地址
      *
      * @return {@link String}
@@ -161,20 +150,13 @@ public class Configurations {
     }
 
     /**
-     * 获取可选收件人列表
+     * 检查用户配置是否为空
      *
-     * @return {@link List}
+     * @return {@code boolean}
      */
-    public List<String> getTargetList() {
-        return targetList;
-    }
-
-    /**
-     * 设置可选收件人列表
-     *
-     * @param targetList 收件人列表
-     */
-    public void setTargetList(final List<String> targetList) {
-        this.targetList = targetList;
+    public final boolean isUnset() {
+        return (
+            "".equals(getEmail()) && "".equals(getSmtp()) && "".equals(getPassword())
+        );
     }
 }

--- a/homework/src/main/java/utils/Configurations.java
+++ b/homework/src/main/java/utils/Configurations.java
@@ -67,7 +67,10 @@ public class Configurations {
         } else if (Constants.SMTP.equals(item)) {
             System.out.println(getSmtp());
         } else if (Constants.KEY.equals(item)) {
-            System.out.println("*".repeat(getPassword().length()));
+            for (int i = 0; i < getPassword().length(); i++) {
+                System.out.print("*");
+            }
+            System.out.println();
         } else if (Constants.DEFAULT_TARGET.equals(item)) {
             System.out.println(getTarget());
         }

--- a/homework/src/main/java/utils/Configurations.java
+++ b/homework/src/main/java/utils/Configurations.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package utils;
 
 import java.util.ArrayList;

--- a/homework/src/main/java/utils/Configurations.java
+++ b/homework/src/main/java/utils/Configurations.java
@@ -1,5 +1,8 @@
 package utils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * 用户配置实例类
  *
@@ -9,6 +12,8 @@ public class Configurations {
     private String email = "";
     private String smtp = "";
     private String password = "";
+    private String target = "";
+    private List<String> targetList = new ArrayList<>();
 
     /**
      * 设置配置
@@ -28,6 +33,12 @@ public class Configurations {
         }
     }
 
+    /**
+     * 输出相应的配置
+     *
+     * @param item
+     *     配置键
+     */
     public void show(final String item) {
         if (Constants.EMAIL.equals(item)) {
             System.out.println(getEmail());
@@ -40,33 +51,57 @@ public class Configurations {
 
     /**
      * 发件电子邮箱
+     *
+     * @return {@link String}
      */
     public final String getEmail() {
         return email;
     }
 
+    /**
+     * 设置发件邮箱地址
+     *
+     * @param email
+     *     电子邮箱地址
+     */
     public void setEmail(final String email) {
         this.email = email;
     }
 
     /**
      * 发件服务器地址
+     *
+     * @return {@link String}
      */
     public final String getSmtp() {
         return smtp;
     }
 
+    /**
+     * 设置发件服务器地址
+     *
+     * @param smtp
+     *     发件SMTP服务器地址
+     */
     public void setSmtp(final String smtp) {
         this.smtp = smtp;
     }
 
     /**
      * 邮箱登陆密码
+     *
+     * @return {@link String}
      */
     public final String getPassword() {
         return password;
     }
 
+    /**
+     * 设置发件密码/授权码
+     *
+     * @param password
+     *     密码/授权码
+     */
     public void setPassword(final String password) {
         this.password = password;
     }
@@ -80,5 +115,42 @@ public class Configurations {
         return (
             "".equals(getEmail()) && "".equals(getSmtp()) && "".equals(getPassword())
         );
+    }
+
+    /**
+     * 获取默认收件地址
+     *
+     * @return {@link String}
+     */
+    public String getTarget() {
+        return target;
+    }
+
+    /**
+     * 设置默认收件人
+     *
+     * @param target
+     *     默认收件人地址
+     */
+    public void setTarget(final String target) {
+        this.target = target;
+    }
+
+    /**
+     * 获取可选收件人列表
+     *
+     * @return {@link List}
+     */
+    public List<String> getTargetList() {
+        return targetList;
+    }
+
+    /**
+     * 设置可选收件人列表
+     *
+     * @param targetList 收件人列表
+     */
+    public void setTargetList(final List<String> targetList) {
+        this.targetList = targetList;
     }
 }

--- a/homework/src/main/java/utils/Constants.java
+++ b/homework/src/main/java/utils/Constants.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package utils;
 
 /**

--- a/homework/src/main/java/utils/Constants.java
+++ b/homework/src/main/java/utils/Constants.java
@@ -45,4 +45,5 @@ public class Constants {
     public static final String EMAIL = "user.email";
     public static final String SMTP = "user.smtp";
     public static final String KEY = "user.key";
+    public static final String DEFAULT_TARGET = "target.default";
 }

--- a/homework/src/main/resources/help.txt
+++ b/homework/src/main/resources/help.txt
@@ -7,7 +7,7 @@ Options:
     -v, --version               Display version information and exit
 
 Commands:
-    push <file> <address>       Send file to a specific address
+    push <file> [<address>]     Send file to default or a specific address
     config <item> <value>       Configure profiles of users
     archive <files> ...         Generate an archive file with
                                 specific files or directories
@@ -17,3 +17,4 @@ There is an available setting item list for command 'homework config':
     user.smtp                   The smtp server of your email address
     user.key                    The password or authentication code of
                                 your email address
+    target.default              Default email address you will send to

--- a/homework/src/test/java/main/AppTest.java
+++ b/homework/src/test/java/main/AppTest.java
@@ -24,6 +24,8 @@
 
 package main;
 
+import java.io.IOException;
+
 import org.junit.Test;
 
 import utils.Constants;
@@ -33,7 +35,7 @@ import utils.Constants;
  */
 public class AppTest {
     @Test
-    public synchronized void illegalTestA() {
+    public synchronized void illegalTestA() throws IOException {
         System.out.println("$ homework --error");
         App.main(new String[] {"--error"});
         System.out.println();
@@ -41,7 +43,7 @@ public class AppTest {
     }
 
     @Test
-    public synchronized void illegalTestB() {
+    public synchronized void illegalTestB() throws IOException {
         System.out.println("$ homework error");
         App.main(new String[] {"error"});
         System.out.println();
@@ -49,7 +51,7 @@ public class AppTest {
     }
 
     @Test
-    public synchronized void helpTestA() {
+    public synchronized void helpTestA() throws IOException {
         System.out.println("$ homework -h");
         App.main(new String[] {Constants.SHORT_HELP});
         System.out.println();
@@ -57,7 +59,7 @@ public class AppTest {
     }
 
     @Test
-    public synchronized void helpTestB() {
+    public synchronized void helpTestB() throws IOException {
         System.out.println("$ homework --help");
         App.main(new String[] {Constants.LONG_HELP});
         System.out.println();
@@ -65,7 +67,7 @@ public class AppTest {
     }
 
     @Test
-    public synchronized void helpTestC() {
+    public synchronized void helpTestC() throws IOException {
         System.out.println("$ homework");
         App.main(new String[] {});
         System.out.println();
@@ -73,7 +75,7 @@ public class AppTest {
     }
 
     @Test
-    public synchronized void versionTestA() {
+    public synchronized void versionTestA() throws IOException {
         System.out.println("$ homework -v");
         App.main(new String[] {Constants.SHORT_VERSION});
         System.out.println();
@@ -81,7 +83,7 @@ public class AppTest {
     }
 
     @Test
-    public synchronized void versionTestB() {
+    public synchronized void versionTestB() throws IOException {
         System.out.println("$ homework --version");
         App.main(new String[] {Constants.LONG_VERSION});
         System.out.println();
@@ -89,7 +91,7 @@ public class AppTest {
     }
 
     @Test
-    public synchronized void integratedTest() {
+    public synchronized void integratedTest() throws IOException {
         // 集成测试
         IntegratedTest.archiveTest();
         IntegratedTest.configTestB();

--- a/homework/src/test/java/main/AppTest.java
+++ b/homework/src/test/java/main/AppTest.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package main;
 
 import org.junit.Test;

--- a/homework/src/test/java/main/IntegratedTest.java
+++ b/homework/src/test/java/main/IntegratedTest.java
@@ -24,10 +24,7 @@
 
 package main;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
+import java.io.*;
 
 import utils.Constants;
 
@@ -41,7 +38,7 @@ public class IntegratedTest {
         "You haven't set your environment variables! "
         + "Please set variable: ";
 
-    static void archiveTest() {
+    static void archiveTest() throws IOException {
         System.out.println(
             "$ homework archive archived src"
         );
@@ -52,7 +49,7 @@ public class IntegratedTest {
         System.out.println();
     }
 
-    static void configTestB() {
+    static void configTestB() throws IOException {
         System.out.println("$ homework config user.email");
         App.main(new String[] {Constants.CONFIG, Constants.EMAIL});
         System.out.println();
@@ -71,7 +68,7 @@ public class IntegratedTest {
         System.out.println();
     }
 
-    static void configTestA() {
+    static void configTestA() throws IOException {
         String[] configs = {
             System.getenv("USER_EMAIL"),
             System.getenv("USER_HOST"),
@@ -100,7 +97,7 @@ public class IntegratedTest {
         System.out.println();
     }
 
-    static void pushTest() {
+    static void pushTest() throws IOException {
         // 输入重定向
         InputStream rawIn = System.in;
         try {

--- a/homework/src/test/java/main/IntegratedTest.java
+++ b/homework/src/test/java/main/IntegratedTest.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Dragon1573
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package main;
 
 import java.io.File;

--- a/homework/src/test/java/main/IntegratedTest.java
+++ b/homework/src/test/java/main/IntegratedTest.java
@@ -65,17 +65,23 @@ public class IntegratedTest {
         App.main(new String[] {Constants.CONFIG, Constants.KEY});
         System.out.println();
         System.out.println();
+        System.out.println("$ homework config target.default");
+        App.main(new String[] {Constants.CONFIG, Constants.DEFAULT_TARGET});
+        System.out.println();
+        System.out.println();
     }
 
     static void configTestA() {
         String[] configs = {
             System.getenv("USER_EMAIL"),
             System.getenv("USER_HOST"),
-            System.getenv("USER_KEY")
+            System.getenv("USER_KEY"),
+            System.getenv("TARGET_EMAIL")
         };
         assert configs[0] != null : errorMessage + "USER_EMAIL";
         assert configs[1] != null : errorMessage + "USER_HOST";
         assert configs[2] != null : errorMessage + "USER_KEY";
+        assert configs[3] != null : errorMessage + "TARGET_EMAIL";
         System.out.println("$ homework config user.email student@example.com");
         App.main(new String[] {Constants.CONFIG, Constants.EMAIL, configs[0]});
         System.out.println();
@@ -86,6 +92,10 @@ public class IntegratedTest {
         System.out.println();
         System.out.println("$ homework config user.key ****************");
         App.main(new String[] {Constants.CONFIG, Constants.KEY, configs[2]});
+        System.out.println();
+        System.out.println();
+        System.out.println("$ homework config target.default teacher@example.com");
+        App.main(new String[] {Constants.CONFIG, Constants.DEFAULT_TARGET, configs[3]});
         System.out.println();
         System.out.println();
     }
@@ -103,10 +113,8 @@ public class IntegratedTest {
         }
 
         // 发信测试
-        System.out.println("$ homework push archived.zip teacher@example.com");
-        final String target = System.getenv("TARGET_EMAIL");
-        assert target != null : errorMessage + "TARGET_EMAIL";
-        App.main(new String[] {Constants.PUSH, "archived.zip", target});
+        System.out.println("$ homework push archived.zip");
+        App.main(new String[] {Constants.PUSH, "archived.zip"});
         System.out.println();
         System.out.println();
 


### PR DESCRIPTION
# 新功能

- [x] 在全局配置文件中添加关于默认收件人的信息
- [x] 若设置了默认收件人地址，执行发件命令时的收件人参数可以省略

# 项目外更新

- [x] 为所有的`*.java`类文件增加`MIT License`

# 未能实现的功能

- 增加候选收件人列表管理功能